### PR TITLE
Update block.js

### DIFF
--- a/admin/src/block.js
+++ b/admin/src/block.js
@@ -16,7 +16,7 @@ import HotComponent from "./hot-component.js"
 
 registerBlockType( 'gutenberg-hot-module-replacement/example', {
 	title: __( 'Hot Module Replacement Example' ),
-	icon: '',
+	icon: 'book-alt',
 	category: 'common',
 	supports: {
 		html: false,


### PR DESCRIPTION
FIX: Dashicon name added to icon field to prevent error when initially running the plugin.